### PR TITLE
Add v2 signing command

### DIFF
--- a/src/sia.ts
+++ b/src/sia.ts
@@ -21,6 +21,7 @@ interface VerifyResponse {
  * const sia = new Sia(transport)
  */
 export default class Sia {
+	v2: bool;
 	transport: Transport;
 
 	constructor(transport: Transport, scrambleKey = 'Sia', v2 = false) {

--- a/src/sia.ts
+++ b/src/sia.ts
@@ -21,11 +21,9 @@ interface VerifyResponse {
  * const sia = new Sia(transport)
  */
 export default class Sia {
-	v2: bool;
 	transport: Transport;
 
-	constructor(transport: Transport, scrambleKey = 'Sia', v2 = false) {
-		this.v2 = v2;
+	constructor(transport: Transport, scrambleKey = 'Sia') {
 		this.transport = transport;
 		transport.decorateAppAPIMethods(this, [
 			'signTransactionV044',
@@ -160,10 +158,6 @@ export default class Sia {
 	 * @returns {string} the base64 encoded signature
 	 */
 	async signV2Transaction(encodedTxn: Buffer, sigIndex: number, keyIndex: number, changeIndex: number) : Promise<string> {
-		if (!this.v2) {
-			throw new Error("v2 signing not enabled");
-		}
-
 		const buf = Buffer.alloc(encodedTxn.length + 10);
 		let resp = Buffer.alloc(0);
 

--- a/src/sia.ts
+++ b/src/sia.ts
@@ -23,11 +23,13 @@ interface VerifyResponse {
 export default class Sia {
 	transport: Transport;
 
-	constructor(transport: Transport, scrambleKey = 'Sia') {
+	constructor(transport: Transport, scrambleKey = 'Sia', v2 = false) {
+		this.v2 = v2;
 		this.transport = transport;
 		transport.decorateAppAPIMethods(this, [
 			'signTransactionV044',
 			'signTransaction',
+			'signV2Transaction',
 			'verifyPublicKey',
 			'verifyStandardAddress'
 		], scrambleKey);
@@ -102,6 +104,7 @@ export default class Sia {
 		buf.set(encodedTxn, 6);
 
 		for (let i = 0; i < buf.length; i += 255) {
+			// INS_GET_TXN_HASH = 0x08
 			resp = await this.transport.send(0xe0,
 				0x08,
 				i === 0 ? 0x00 : 0x80,
@@ -136,8 +139,45 @@ export default class Sia {
 		buf.set(encodedTxn, 10);
 
 		for (let i = 0; i < buf.length; i += 255) {
+			// INS_GET_TXN_HASH = 0x08
 			resp = await this.transport.send(0xe0,
 				0x08,
+				i === 0 ? 0x00 : 0x80,
+				0x01,
+				Buffer.from(buf.subarray(i, i + 255)));
+		}
+
+		return encode(resp);
+	}
+
+	/**
+	 * signV2Transaction signs the v2 transaction with the provided key
+	 * @param encodedTxn {Buffer} a sia encoded (V2TransactionSemantics) v2 transaction
+	 * @param sigIndex {number} the index of the signature to sign
+	 * @param keyIndex {number} the index of the key to sign with
+	 * @param changeIndex {number} the index of the key used for the change output
+	 * @returns {string} the base64 encoded signature
+	 */
+	async signV2Transaction(encodedTxn: Buffer, sigIndex: number, keyIndex: number, changeIndex: number) : Promise<string> {
+		if (!this.v2) {
+			throw new Error("v2 signing not enabled");
+		}
+
+		const buf = Buffer.alloc(encodedTxn.length + 10);
+		let resp = Buffer.alloc(0);
+
+		if (encodedTxn.length === 0)
+			throw new Error('empty transaction');
+
+		buf.writeUInt32LE(keyIndex, 0);
+		buf.writeUInt16LE(sigIndex, 4);
+		buf.writeUInt32LE(changeIndex, 6);
+		buf.set(encodedTxn, 10);
+
+		for (let i = 0; i < buf.length; i += 255) {
+			// INS_GET_V2TXN_HASH = 0x10
+			resp = await this.transport.send(0xe0,
+				0x10,
 				i === 0 ? 0x00 : 0x80,
 				0x01,
 				Buffer.from(buf.subarray(i, i + 255)));


### PR DESCRIPTION
Same encoding as for v1 transactions: indices first then the encoded transaction.

https://github.com/SiaFoundation/app-sia-x/blob/241f7258d8937a755976eb041834eaa561cd9e74/cmd/sialedger/main.go#L293